### PR TITLE
Fix spellcheck and code style.

### DIFF
--- a/src/DataCollector/MailjetDataCollector.php
+++ b/src/DataCollector/MailjetDataCollector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mailjet\MailjetBundle\DataCollector;
 
 use Mailjet\MailjetBundle\Client\MailjetClient;
@@ -18,19 +19,21 @@ class MailjetDataCollector extends DataCollector
     protected $client;
 
     /**
-     * Mailjet client for transactionnal email (swiftmailer)
+     * Mailjet client for transactional email (swiftmailer)
      * @var MailjetClient
      */
-    protected $transactionnalClient;
+    protected $transactionalClient;
 
     /**
      * @param MailjetClient $client
+     * @param MailjetClient $transactionalClient
      */
-    public function __construct(MailjetClient $client, MailjetClient $transactionnalClient)
+    public function __construct(MailjetClient $client, MailjetClient $transactionalClient)
     {
         $this->client = $client;
-        $this->transactionnalClient = $transactionnalClient;
+        $this->transactionalClient = $transactionalClient;
     }
+
     /**
      * Collects data for the given Request and Response.
      *
@@ -42,8 +45,9 @@ class MailjetDataCollector extends DataCollector
     {
 
         $this->data = $this->client->getCalls();
-        $this->data = array_merge($this->data, $this->transactionnalClient->getCalls());
+        $this->data = array_merge($this->data, $this->transactionalClient->getCalls());
     }
+
     /**
      * Returns the name of the collector.
      *


### PR DESCRIPTION
Symfony 3 outputs deprecated param usage message when container param is not in quotes.
Updated code - use single quotes.